### PR TITLE
Fix build for LTS-14.20

### DIFF
--- a/hoggl.cabal
+++ b/hoggl.cabal
@@ -27,7 +27,7 @@ library
                      , either
                      , formatting
                      , hashable
-                     , http-client < 0.6
+                     , http-client
                      , http-client-tls
                      , mtl
                      , servant >= 0.9

--- a/src/Network/Hoggl.hs
+++ b/src/Network/Hoggl.hs
@@ -55,7 +55,7 @@ listProjects' :: Maybe Token -> WorkspaceId -> ClientM [Project]
 currentTimeEntry :: Token -> ClientM (Maybe TimeEntry)
 currentTimeEntry token = (Just <$> currentTimeEntry' (Just token)) `catchError` handler
   where
-    handler :: ServantError -> ClientM (Maybe TimeEntry)
+    handler :: ClientError -> ClientM (Maybe TimeEntry)
     handler (DecodeFailure "{\"data\":null}" _) = return Nothing
     handler e = throwError e
 

--- a/src/Network/Hoggl/Types.hs
+++ b/src/Network/Hoggl/Types.hs
@@ -80,7 +80,7 @@ instance ToHttpApiData Token where
    toUrlPiece (Api token) = toUrlPiece $ "Basic " ++ encode (token ++ ":api_token")
    toUrlPiece (UserPass user pass) = toUrlPiece $ "Basic " ++ encode (user ++ ":" ++ pass)
 
-data HogglError = ServantError ServantError | HogglError String deriving Show
+data HogglError = ServantError ClientError | HogglError String deriving Show
 
 data TimeEntryStart = TES { tesDescription :: Maybe Text
                           , tesTags :: [Text]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.5
+resolver: lts-14.20
 
 packages:
   - '.'


### PR DESCRIPTION
The builds fails due to a version bound for `http-client` and an API change in `servant`. 