### PR TITLE
fix build for ghc-8.8 (lts-15.4)

### DIFF
--- a/src/Network/Hoggl/Types.hs
+++ b/src/Network/Hoggl/Types.hs
@@ -58,7 +58,7 @@ instance FromJSON ISO6801 where
   parseJSON (String s) = ISO6801 <$> parseTimeStamp s
   parseJSON _ = mzero
 
-parseTimeStamp :: Monad m => Text -> m UTCTime
+parseTimeStamp :: (MonadFail m, Monad m) => Text -> m UTCTime
 parseTimeStamp ts =
   parseTimeM True
              defaultTimeLocale

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.20
+resolver: lts-15.4
 
 packages:
   - '.'


### PR DESCRIPTION
`parseTimeM` from time explicitely asks for MonadFail